### PR TITLE
Use yaml.safe_load

### DIFF
--- a/wikigrok-aggregation-test.py
+++ b/wikigrok-aggregation-test.py
@@ -21,7 +21,7 @@ class Aggregator():
     def load_config(self, config_path):
         """Load config"""
         with open(config_path) as config_file:
-            self.config.update(yaml.load(config_file))
+            self.config.update(yaml.safe_load(config_file))
 
     def _get_claims(self):
         raw_events = open('claims.tsv', 'r')


### PR DESCRIPTION
Unfortunately the default implementation of yaml.load is just like PHP's serialize,
it can possibly execute arbitrary code. In this case the yaml file is controlled by us,
but let's use safe defaults and encourage good code conventions and use 
safe_load, which does not have those issues.
